### PR TITLE
Create Chat Table and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,53 @@ java 17.0.2 2022-01-18 LTS
 Java(TM) SE Runtime Environment (build 17.0.2+8-LTS-86)
 Java HotSpot(TM) 64-Bit Server VM (build 17.0.2+8-LTS-86, mixed mode, sharing)
 ```
+
+
+## Docker Development Worflow
+
+### Kick off all the containers
+
+```bash
+docker-compose rm -svf && docker-compose up
+```
+
+### Run Kafka CLI:
+
+Create a topic:
+``` bash
+docker exec -it CONTAINER_ID kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 --topic charlytest
+```
+
+List of topics:
+``` bash
+docker exec -it CONTAINER_ID kafka-topics.sh --bootstrap-server localhost:9092 --list
+```
+
+Get topics information
+``` bash
+docker exec -it CONTAINER_ID kafka-topics.sh --bootstrap-server localhost:9092 --describe
+```
+
+Console Producer using key and acks
+
+In this case 12345 is the key and hello de message content (Useful to put all the messages in the same partition using the user_id)
+
+```bash
+docker exec -it CONTAINER_ID kafka-console-producer.sh  --bootstrap-server localhost:9092 --topic charlytest --producer-property acks=all --property parse.key=true --property key.separator=:
+
+>> 12345:hello
+```
+
+### Access to Cassandra:
+
+```bash
+docker exec -it CONTAINER_ID cqlsh
+```
+
+
+### Get the network information
+
+
+```bash
+docker network ls | grep "camel"
+```

--- a/chat-microservice/README.md
+++ b/chat-microservice/README.md
@@ -25,6 +25,12 @@ Server Tests
 
 `export TESTING_MODE=1 && pytest app/tests/api --disable-warnings -rP`
 
+Run a specific test case
+
+`export TESTING_MODE=1 && pytest app/tests/api --disable-warnings -rP -k test_no_allow_create_chat_message_if_to_user_not_match`
+
+- Do not user UID as user ids for creating JWT. It will raise 403. Also users id are integers because the database is Postgres 
+
 
 ## Access to cassandra in development
 

--- a/chat-microservice/app/api/deps.py
+++ b/chat-microservice/app/api/deps.py
@@ -1,7 +1,6 @@
 from fastapi import Depends
 
 from app.core.kafka import kafka_producer
-from app.models.chat_messages import ChatMessages
 from app.core.config import settings
 
 from auth_validator import AuthValidator
@@ -15,12 +14,6 @@ Kafka Producer instance as dependency in order to easy mock it
 """
 def get_kafka_producer():
     return kafka_producer
-
-"""
-Model as dependency in order to easy mock it
-"""
-def get_chat_message_model():
-    return ChatMessages
 
 """
 Tiny helper to retrieve the user id from then JWT token

--- a/chat-microservice/app/api/v1/__init__.py
+++ b/chat-microservice/app/api/v1/__init__.py
@@ -1,6 +1,9 @@
 from fastapi import APIRouter
 
 from app.api.v1.messaging import router as messaging_router
+from app.api.v1.chat import router as chat_router
+
 
 router = APIRouter(prefix="/v1")
 router.include_router(messaging_router)
+router.include_router(chat_router)

--- a/chat-microservice/app/api/v1/chat.py
+++ b/chat-microservice/app/api/v1/chat.py
@@ -1,0 +1,55 @@
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import JSONResponse
+
+from app.schemas.chat import ChatSentREST, ChatCreatedResponse
+from app.core.config import settings
+from app.models.chat import Chat
+from ..deps import (
+    get_token_data,
+    get_current_user_id
+)
+
+
+router = APIRouter(tags=["Chat"])
+
+@router.post(
+    "/chat/", 
+    response_model=ChatCreatedResponse, 
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(get_token_data)]
+)
+async def create_chat(
+    chat: ChatSentREST, 
+    current_user_id = Depends(get_current_user_id)
+):
+    """
+    Create a chat between users using this endpoint
+
+    - **users_id**: List of users ID
+    """
+
+    # TODO
+    # Query user 1
+    # Return error if user does not exist
+    # user_1_id = 
+    # user_1_name = 
+
+    # TODO
+    # Query user 2
+    # Return error if user does not exist
+    # user_2_id =
+    # user_2_name =
+
+    # TODO: Validate there is not already a chat with the two users
+    
+    # TODO: Try Catch and raise error
+
+    new_chat = Chat.create(
+        chat_id = str(uuid.uuid4()),
+        users_id = [user_1_id, user_2_id],
+        users_name = [user_1_name, user_2_name]
+    )
+
+    #  TODO: Return JSON

--- a/chat-microservice/app/api/v1/chat.py
+++ b/chat-microservice/app/api/v1/chat.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
@@ -25,31 +26,25 @@ async def create_chat(
     current_user_id = Depends(get_current_user_id)
 ):
     """
-    Create a chat between users using this endpoint
-
+    Create a chat between users using this endpoint.
+    Validate if current user id in user_id
+    This endpoint is not validating if the users id already exists.
+    This endpoint does not have way to get the users name.
     - **users_id**: List of users ID
     """
-
-    # TODO
-    # Query user 1
-    # Return error if user does not exist
-    # user_1_id = 
-    # user_1_name = 
-
-    # TODO
-    # Query user 2
-    # Return error if user does not exist
-    # user_2_id =
-    # user_2_name =
-
-    # TODO: Validate there is not already a chat with the two users
-    
-    # TODO: Try Catch and raise error
-
+    if str(current_user_id) not in chat.users_id:
+        raise HTTPException(
+            status_code=401, detail='User is not authorized to do this action'
+        )
+    user_1_id, user_2_id = chat.users_id
+    if Chat.users_id_belongs_to_chat(None, user_1_id, user_2_id):
+        raise HTTPException(
+            status_code=422, detail='There is a chat for this users'
+        )
+    user_1_name, user_2_name = ['Pepe', 'Fefo'] # HOW
     new_chat = Chat.create(
         chat_id = str(uuid.uuid4()),
         users_id = [user_1_id, user_2_id],
         users_name = [user_1_name, user_2_name]
     )
-
-    #  TODO: Return JSON
+    return new_chat

--- a/chat-microservice/app/api/v1/messaging.py
+++ b/chat-microservice/app/api/v1/messaging.py
@@ -2,7 +2,6 @@ import json
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
-from cassandra import WriteFailure
 
 from app.schemas.message import MessageSentREST, MessageCreatedResponse
 from app.core.config import settings

--- a/chat-microservice/app/api/v1/messaging.py
+++ b/chat-microservice/app/api/v1/messaging.py
@@ -30,16 +30,20 @@ async def create_message(
 ):
     """
     The user send a message using this endpoint
-    Save the message in cassandra in async way
-    Send the message to the kafka topic to use in apache camel
+    Save the message in cassandra in async way (TODO async)
+    Send the message to the kafka topic to use it in apache camel in async way (TODO async)
     Message ID and the timestamp automatically created
 
+    - **chat_id**: ID of the chat
     - **body**: Message text
     - **from_user**: ID of the user that wrote it
     - **to_user**: ID of the user that need the message back
     """
     if str(current_user_id) != str(message.from_user):
-        # TODO: Validate if there are a Chat with the chat_id and the current_user_id is inside users_id
+        raise HTTPException(
+            status_code=401, detail=settings.CASSANDRA_MESSAGE_CREATION_UNAUTHORIZED
+        )
+    if not Chat.users_id_belongs_to_chat(message.chat_id, message.from_user, message.to_user):
         raise HTTPException(
             status_code=401, detail=settings.CASSANDRA_MESSAGE_CREATION_UNAUTHORIZED
         )

--- a/chat-microservice/app/core/config.py
+++ b/chat-microservice/app/core/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     CASSANDRA_MESSAGE_CREATION_ERROR: Optional[str] = None
     CASSANDRA_MESSAGE_CREATION_UNAUTHORIZED: Optional[str] = None
     KAFKA_BOOTSTRAP_SERVER: str
+    CASSANDRA_KEYSPACE_TESTING: str = 'python_test_environment'
 
     class Config:
         # Relative to main.py

--- a/chat-microservice/app/models/chat.py
+++ b/chat-microservice/app/models/chat.py
@@ -11,6 +11,7 @@ class Chat(models.Model):
     All users name inside users_id.
     Queries that this model meet:
     Q1 - Find all chats where a user is
+    Q2 - Check if two users belongs to the same chat
     """
     __table_name__ = 'chat'
     chat_id = columns.UUID(primary_key=True, partition_key=True, default=uuid4)
@@ -19,3 +20,20 @@ class Chat(models.Model):
 
     def __repr__(self):
         return f'{self.chat_id} {self.users_id} {self.users_name}'
+
+    """
+    Query to find if there are chats with the from_user_id on it
+    And then loop the chats to find the to_user_id
+    Return a boolean value
+    """
+    @staticmethod
+    def users_id_belongs_to_chat(chat_id: str, from_user_id: str, to_user_id: str) -> bool:
+        chats = Chat.objects().filter(
+            chat_id=chat_id,
+            users_id__contains=f"{from_user_id}"
+        ).allow_filtering().all()
+        for chat in chats:
+            if to_user_id in list(chat.users_id):
+                return True
+        return False
+

--- a/chat-microservice/app/models/chat.py
+++ b/chat-microservice/app/models/chat.py
@@ -1,0 +1,21 @@
+from uuid import uuid1,uuid4
+
+from cassandra.cqlengine import columns, connection, management, models, query
+
+# https://stackoverflow.com/a/24291261
+class Chat(models.Model):
+    """Chat Model
+    To start a conversation we must create a Chat record.
+    With a unique chat_id.
+    All users id inside users_id.
+    All users name inside users_id.
+    Queries that this model meet:
+    Q1 - Find all chats where a user is
+    """
+    __table_name__ = 'chat'
+    chat_id = columns.UUID(primary_key=True, partition_key=True, default=uuid4)
+    users_id = columns.Set(value_type=columns.Text)
+    users_name = columns.Set(value_type=columns.Text)
+
+    def __repr__(self):
+        return f'{self.chat_id} {self.users_id} {self.users_name}'

--- a/chat-microservice/app/models/chat.py
+++ b/chat-microservice/app/models/chat.py
@@ -1,4 +1,4 @@
-from uuid import uuid1,uuid4
+from uuid import uuid4
 
 from cassandra.cqlengine import columns, connection, management, models, query
 

--- a/chat-microservice/app/models/chat.py
+++ b/chat-microservice/app/models/chat.py
@@ -28,10 +28,12 @@ class Chat(models.Model):
     """
     @staticmethod
     def users_id_belongs_to_chat(chat_id: str, from_user_id: str, to_user_id: str) -> bool:
-        chats = Chat.objects().filter(
-            chat_id=chat_id,
-            users_id__contains=f"{from_user_id}"
-        ).allow_filtering().all()
+        kwargs = {
+            "users_id__contains": f"{from_user_id}"
+        }
+        if chat_id is not None:
+            kwargs["chat_id"] = chat_id
+        chats = Chat.objects().filter(**kwargs).allow_filtering().all()
         for chat in chats:
             if to_user_id in list(chat.users_id):
                 return True

--- a/chat-microservice/app/models/chat_messages.py
+++ b/chat-microservice/app/models/chat_messages.py
@@ -4,13 +4,20 @@ from cassandra.cqlengine import columns, connection, management, models, query
 
 # https://stackoverflow.com/a/24291261
 class ChatMessages(models.Model):
-    """Chat Messages Object Mapper Model"""
+    """
+    ChatMessages saves the messages that belong to a Chat.
+    With a unique message_id.
+    The chat_id belong to a Chat record.
+    Queries that this model meet:
+    Q1 - Get the last N message by a chat_id
+    """
     __table_name__ = 'chat_messages'
+    chat_id    = columns.Text(primary_key=True, partition_key=True)
+    from_user  = columns.Text()
+    to_user    = columns.Text()
     message_id = columns.UUID(default=uuid4)
-    from_user = columns.Text(primary_key=True, partition_key=True)
-    to_user = columns.Text(primary_key=True, partition_key=True)
-    body = columns.Text()
-    time = columns.TimeUUID(primary_key=True, default=uuid1, clustering_order='DESC')
+    body       = columns.Text()
+    time       = columns.TimeUUID(primary_key=True, default=uuid1, clustering_order='DESC')
 
     def __repr__(self):
-        return f'{self.message_id} {self.from_user} {self.to_user} {self.body} {self.time}'
+        return f'{self.chat_id} {self.message_id} {self.from_user} {self.to_user} {self.body} {self.time}'

--- a/chat-microservice/app/schemas/chat.py
+++ b/chat-microservice/app/schemas/chat.py
@@ -1,9 +1,20 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
+from typing import List
 from uuid import UUID
 
 class ChatSentREST(BaseModel):
-    users_id: str[]
-    
+    users_id: List[str]
+        
+    @validator('users_id')
+    def users_id_uniques(cls, v):
+        assert len(set(v)) == len(v), 'must be uniques values'
+        return v
+
+    @validator('users_id')
+    def users_id_length(cls, v):
+        assert len(v) == 2, 'must has two values'
+        return v
+
     class Config:
         schema_extra = {
             "example": {
@@ -13,12 +24,14 @@ class ChatSentREST(BaseModel):
 
 class ChatCreatedResponse(BaseModel):
     chat_id: UUID
-    users_id: str = Field(..., min_items=2, max_items=2)
-    # TODO: Validate users_id unique values
+    users_id: List[str]
+    users_name: List[str]
+
     class Config:
         schema_extra = {
             "example": {
                 "chat_id": "808a156a-672d-4604-ab3d-355bc3445e2e",
-                "users_id": ['1', '2']
+                "users_id": ['1', '2'],
+                "users_name": ["Pepe", "Foo"]
             }
         }

--- a/chat-microservice/app/schemas/chat.py
+++ b/chat-microservice/app/schemas/chat.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, Field
+from uuid import UUID
+
+class ChatSentREST(BaseModel):
+    users_id: str[]
+    
+    class Config:
+        schema_extra = {
+            "example": {
+                "users_id": [1, 2]
+            }
+        }
+
+class ChatCreatedResponse(BaseModel):
+    chat_id: UUID
+    users_id: str = Field(..., min_items=2, max_items=2)
+    # TODO: Validate users_id unique values
+    class Config:
+        schema_extra = {
+            "example": {
+                "chat_id": "808a156a-672d-4604-ab3d-355bc3445e2e",
+                "users_id": ['1', '2']
+            }
+        }

--- a/chat-microservice/app/schemas/message.py
+++ b/chat-microservice/app/schemas/message.py
@@ -6,13 +6,15 @@ class MessageSentREST(BaseModel):
     body: str
     from_user: str
     to_user: str
+    chat_id: str
     
     class Config:
         schema_extra = {
             "example": {
                 "body": "Hello bro!",
                 "from_user": "1",
-                "to_user": "2"
+                "to_user": "2",
+                "chat_id": "808a156a-672d-4604-ab3d-355bc3445e2e"
             }
         }
 
@@ -21,6 +23,7 @@ class MessageCreatedResponse(BaseModel):
     from_user: str
     to_user: str
     body: str
+    chat_id: str
     time: UUID
 
     class Config:
@@ -30,6 +33,7 @@ class MessageCreatedResponse(BaseModel):
                 "from_user": "1",
                 "to_user": "1",
                 "body": "Hello bro!",
+                "chat_id": "808a156a-672d-4604-ab3d-355bc3445e2e",
                 "time": "935b7ae6-afc1-11ec-b85d-b29c4ace6a4c"
             }
         }

--- a/chat-microservice/app/schemas/message.py
+++ b/chat-microservice/app/schemas/message.py
@@ -6,7 +6,7 @@ class MessageSentREST(BaseModel):
     body: str
     from_user: str
     to_user: str
-    chat_id: str
+    chat_id: UUID
     
     class Config:
         schema_extra = {

--- a/chat-microservice/app/tests/api/test_create_chat_endpoint.py
+++ b/chat-microservice/app/tests/api/test_create_chat_endpoint.py
@@ -1,0 +1,94 @@
+import pytest
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chat_messages import ChatMessages
+from app.models.chat import Chat
+
+@pytest.mark.asyncio()
+async def test_create_chat_created_201(
+  client: AsyncSession, 
+  user_token_header: dict[str, str], 
+  main_from_user_uid: str,
+  main_to_user_uid: str,
+  cassandra_session
+):
+    users_id = [main_from_user_uid, main_to_user_uid]
+    res = await client.post(
+      f"/api/v1/chat/",
+      json={
+        "users_id": users_id,
+      }, 
+      headers=user_token_header
+    )
+    data = res.json()
+    assert res.status_code == 201
+    assert Chat.objects().count() == 1
+    assert 'chat_id' in data 
+    assert 'users_id' in data
+    assert 'users_name' in data
+    assert main_from_user_uid in data['users_id']
+    assert main_to_user_uid in data['users_id']
+
+@pytest.mark.asyncio()
+async def test_create_chat_current_user_not_in_users_id_401(
+  client: AsyncSession, 
+  user_token_header: dict[str, str], 
+  main_from_user_uid: str,
+  main_to_user_uid: str,
+  cassandra_session
+):
+    res = await client.post(
+      f"/api/v1/chat/",
+      json={
+        "users_id": [400, 200],
+      }, 
+      headers=user_token_header
+    )
+    data = res.json()
+    assert res.status_code == 401
+    assert data['detail'] == 'User is not authorized to do this action'
+    assert Chat.objects().count() == 0
+
+@pytest.mark.asyncio()
+async def test_create_chat_user_not_authorized_401(
+  client: AsyncSession, 
+  main_from_user_uid: str,
+  main_to_user_uid: str,
+  cassandra_session
+):
+    res = await client.post(
+      f"/api/v1/chat/",
+      json={
+        "users_id": [400, 200],
+      }
+    )
+    data = res.json()
+    assert res.status_code == 401
+    assert Chat.objects().count() == 0
+
+@pytest.mark.asyncio()
+async def test_create_chat_already_exist_the_chat(
+  client: AsyncSession, 
+  user_token_header,
+  main_from_user_uid: str,
+  main_to_user_uid: str,
+  cassandra_session
+):
+    users_id = [main_from_user_uid, main_to_user_uid]
+    chat = Chat.create(
+        chat_id = str(uuid.uuid4()),
+        users_id = users_id,
+        users_name = ["Frank", "Pepe"]
+    )
+    res = await client.post(
+      f"/api/v1/chat/",
+      json={
+        "users_id": users_id
+      },
+      headers=user_token_header
+    )
+    data = res.json()
+    assert res.status_code == 422
+    assert data['detail'] == 'There is a chat for this users'

--- a/chat-microservice/app/tests/api/test_create_message_endpoint.py
+++ b/chat-microservice/app/tests/api/test_create_message_endpoint.py
@@ -1,21 +1,29 @@
 import pytest
+import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.chat_messages import ChatMessages
+from app.models.chat import Chat
 
 @pytest.mark.asyncio()
 async def test_create_chat_message_201(
   client: AsyncSession, 
   user_token_header: dict[str, str], 
-  current_user_id: str,
+  main_from_user_uid: str,
+  main_to_user_uid: str,
   cassandra_session
 ):
+    chat = Chat.create(
+        chat_id = str(uuid.uuid4()),
+        users_id = [main_from_user_uid, main_to_user_uid],
+        users_name = ["Frank", "Pepe"]
+    )  
     new_message = {
-      "from_user": current_user_id,
-      "to_user": '1',
+      "from_user": main_from_user_uid,
+      "to_user": main_to_user_uid,
       "body": f'Message Body',
-      "chat_id": "123"
+      "chat_id": str(chat.chat_id)
     }
     res = await client.post(
       f"/api/v1/messaging/",
@@ -23,6 +31,7 @@ async def test_create_chat_message_201(
       headers=user_token_header
     )
     data = res.json()
+    print(res)
     assert res.status_code == 201
     assert ChatMessages.objects().count() == 1
 
@@ -30,12 +39,13 @@ async def test_create_chat_message_201(
 async def test_create_chat_message_401(
   client: AsyncSession, 
   unauthorized_user_token_header: dict[str, str], 
-  current_user_id: str,
+  main_from_user_uid: str,
+  main_to_user_uid: str,
   cassandra_session
 ):
     new_message = {
-      "from_user": current_user_id,
-      "to_user": '1',
+      "from_user": main_from_user_uid,
+      "to_user": main_to_user_uid,
       "body": f'Message Body',
       "chat_id": "123"
     }
@@ -49,14 +59,14 @@ async def test_create_chat_message_401(
     assert ChatMessages.objects().count() == 0
 
 @pytest.mark.asyncio()
-async def test_create_chat_message_422(
+async def test_create_chat_message_422_no_chat_id(
   client: AsyncSession, 
   user_token_header: dict[str, str], 
-  current_user_id: str,
+  main_from_user_uid: str,
   cassandra_session
 ):
     new_message = {
-      "from_user": current_user_id,
+      "from_user": main_from_user_uid,
       "to_user": 1,
       "body": ["Hello"]
     }
@@ -67,4 +77,84 @@ async def test_create_chat_message_422(
     )
     data = res.json()
     assert res.status_code == 422
+    assert ChatMessages.objects().count() == 0
+
+@pytest.mark.asyncio()
+async def test_no_allow_create_chat_message_if_chat_not_found(
+  client: AsyncSession, 
+  user_token_header: dict[str, str], 
+  main_from_user_uid: str,
+  cassandra_session
+):
+    new_message = {
+      "from_user": main_from_user_uid,
+      "to_user": '1',
+      "body": f'Message Body',
+      "chat_id": str(uuid.uuid4())
+    }
+    res = await client.post(
+      f"/api/v1/messaging/",
+      json=new_message, 
+      headers=user_token_header
+    )
+    data = res.json()
+    assert res.status_code == 401
+    assert ChatMessages.objects().count() == 0
+
+@pytest.mark.asyncio()
+async def test_no_allow_create_chat_message_if_to_user_not_match(
+  client: AsyncSession, 
+  user_token_header: dict[str, str], 
+  main_from_user_uid: str,
+  main_to_user_uid: str,
+  cassandra_session
+):
+    wrong_to_user_id = "101"
+    chat = Chat.create(
+        chat_id = str(uuid.uuid4()),
+        users_id = [main_from_user_uid, main_to_user_uid],
+        users_name = ["Frank", "Pepe"]
+    )  
+    new_message = {
+      "from_user": main_from_user_uid,
+      "to_user": wrong_to_user_id,
+      "body": f'Message Body',
+      "chat_id": str(chat.chat_id)
+    }
+    res = await client.post(
+      f"/api/v1/messaging/",
+      json=new_message, 
+      headers=user_token_header
+    )
+    data = res.json()
+    assert res.status_code == 401
+    assert ChatMessages.objects().count() == 0
+
+@pytest.mark.asyncio()
+async def test_no_allow_create_chat_message_if_from_user_not_match(
+  client: AsyncSession, 
+  user_token_header: dict[str, str], 
+  main_from_user_uid: str,
+  main_to_user_uid: str,
+  cassandra_session
+):
+    wrong_from_user_id = "101"
+    chat = Chat.create(
+        chat_id = str(uuid.uuid4()),
+        users_id = [wrong_from_user_id, main_to_user_uid],
+        users_name = ["Frank", "Pepe"]
+    )  
+    new_message = {
+      "from_user": main_from_user_uid,
+      "to_user": main_to_user_uid,
+      "body": f'Message Body',
+      "chat_id": str(chat.chat_id)
+    }
+    res = await client.post(
+      f"/api/v1/messaging/",
+      json=new_message, 
+      headers=user_token_header
+    )
+    data = res.json()
+    assert res.status_code == 401
     assert ChatMessages.objects().count() == 0

--- a/chat-microservice/app/tests/api/test_create_message_endpoint.py
+++ b/chat-microservice/app/tests/api/test_create_message_endpoint.py
@@ -31,7 +31,6 @@ async def test_create_chat_message_201(
       headers=user_token_header
     )
     data = res.json()
-    print(res)
     assert res.status_code == 201
     assert ChatMessages.objects().count() == 1
 

--- a/chat-microservice/app/tests/api/test_create_message_endpoint.py
+++ b/chat-microservice/app/tests/api/test_create_message_endpoint.py
@@ -4,7 +4,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.chat_messages import ChatMessages
 
-
 @pytest.mark.asyncio()
 async def test_create_chat_message_201(
   client: AsyncSession, 
@@ -15,7 +14,8 @@ async def test_create_chat_message_201(
     new_message = {
       "from_user": current_user_id,
       "to_user": '1',
-      "body": f'Message Body'
+      "body": f'Message Body',
+      "chat_id": "123"
     }
     res = await client.post(
       f"/api/v1/messaging/",
@@ -36,7 +36,8 @@ async def test_create_chat_message_401(
     new_message = {
       "from_user": current_user_id,
       "to_user": '1',
-      "body": f'Message Body'
+      "body": f'Message Body',
+      "chat_id": "123"
     }
     res = await client.post(
       f"/api/v1/messaging/",

--- a/chat-microservice/app/tests/cassandra/test_chat_message_model.py
+++ b/chat-microservice/app/tests/cassandra/test_chat_message_model.py
@@ -73,7 +73,7 @@ def test_pagination_and_relationship(cassandra_session):
     assert page_1[1]["body"] == conversation[9].body
     assert page_1[2]["body"] == conversation[8].body
     
-    last_time = page_1[2]["time"]
+    last_time = page_1[-1]["time"]
 
     page_2 = ChatMessages.objects(
         chat_id=str(chat_record.chat_id)
@@ -86,7 +86,7 @@ def test_pagination_and_relationship(cassandra_session):
     assert page_2[3]["body"] == conversation[4].body
     assert page_2[4]["body"] == conversation[3].body
 
-    last_time = page_2[4]["time"]
+    last_time = page_2[-1]["time"]
 
     page_3 = ChatMessages.objects(
         chat_id=str(chat_record.chat_id)

--- a/chat-microservice/app/tests/cassandra/test_chat_message_model.py
+++ b/chat-microservice/app/tests/cassandra/test_chat_message_model.py
@@ -1,84 +1,98 @@
 import uuid
 
 from app.models.chat_messages import ChatMessages
+from app.models.chat import Chat
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ChatMessage:
+    """Class for keeping track of an item in inventory."""
+    from_user: str
+    to_user: str
+    chat_id: str
+    body: str
 
 def test_create_a_single_record(cassandra_session):
     model_instance = ChatMessages.create(
         from_user=str(uuid.uuid4()),
         to_user=str(uuid.uuid4()),
+        chat_id=str(uuid.uuid4()),
         body='Test Body'
     )
     assert ChatMessages.objects().count() == 1
 
-def test_get_all_messages_between_two_users(cassandra_session):
-    from_user_id = str(uuid.uuid4())
-    to_user_id = str(uuid.uuid4())
-    quantity = 9
+def test_pagination_and_relationship(cassandra_session):
+    frank_id = str(uuid.uuid4())
+    pepe_id = str(uuid.uuid4())
+    
+    chat_record = Chat.create(
+        users_id = [str(uuid.uuid4()), str(uuid.uuid4())],
+        users_name = ["Frank", "Pepe"]
+    )
 
-    for i in range(1, quantity + 1):
-        model_instance = ChatMessages.create(
-            from_user=from_user_id,
-            to_user=to_user_id,
-            body=f'Message Number {str(i)}'
+    # Create a conversation between Frank and Pepe
+
+    conversation = [
+        ChatMessage(frank_id, pepe_id, chat_record.chat_id, 'Hello Pepe!'),
+        ChatMessage(pepe_id, frank_id, chat_record.chat_id, 'Hello Frank!'),
+        ChatMessage(frank_id, pepe_id, chat_record.chat_id, 'How are you Pepe?'),
+        ChatMessage(pepe_id, frank_id, chat_record.chat_id, 'Fine'),
+        ChatMessage(pepe_id, frank_id, chat_record.chat_id, 'What about you Frank?'),
+        ChatMessage(frank_id, pepe_id, chat_record.chat_id, 'Pepe my mom died I am very sad'),
+        ChatMessage(pepe_id, frank_id, chat_record.chat_id, 'Damn it, What a pitty'),
+        ChatMessage(frank_id, pepe_id, chat_record.chat_id, 'Yes bro, very sad'),
+        ChatMessage(pepe_id, frank_id, chat_record.chat_id, 'By the way Frank, I need your help'),
+        ChatMessage(frank_id, pepe_id, chat_record.chat_id, 'For what?'),
+        ChatMessage(pepe_id, frank_id, chat_record.chat_id, 'To be happy Frank, I miss you (Romantic music turn on)'),
+    ]
+
+    for m in conversation:
+        ChatMessages.create(
+            from_user=m.from_user, 
+            to_user=m.to_user, 
+            chat_id=str(m.chat_id), 
+            body=m.body
         )
-
-    all_messages_asc_order = ChatMessages.objects(
-        from_user=from_user_id, to_user=to_user_id
-    )
-
-    assert all_messages_asc_order[0].body == 'Message Number 9'
-
-    assert len(all_messages_asc_order) == quantity
-
-
-def test_paginate_messages(cassandra_session):
-    from_user_id = str(uuid.uuid4())
-    to_user_id = str(uuid.uuid4())
-    quantity = 100
-
-    ChatMessages.create(
-        from_user="OTHER",
-        to_user='OTHER',
-        body=f'Message Number OTHER'
-    )
-
-    for i in range(1, quantity + 1):
-        model_instance = ChatMessages.create(
-            from_user=from_user_id,
-            to_user=to_user_id,
-            body=f'Message Number {str(i)}'
+        ChatMessages.create(
+            from_user="X", 
+            to_user="Y", 
+            chat_id="Z", 
+            body="Noise Message"
         )
+    
+    assert ChatMessages.objects().count() == len(conversation) * 2
 
-    ChatMessages.create(
-        from_user="OTHER",
-        to_user='OTHER',
-        body=f'Message Number OTHER'
-    )
+    page_1 = ChatMessages.objects(
+        chat_id=str(chat_record.chat_id)
+    ).limit(3)
 
-    results = ChatMessages.objects(
-        from_user=from_user_id, to_user=to_user_id
-    ).limit(10)
+    assert len(page_1) == 3
+    assert page_1[0]["body"] == conversation[10].body
+    assert page_1[1]["body"] == conversation[9].body
+    assert page_1[2]["body"] == conversation[8].body
+    
+    last_time = page_1[2]["time"]
 
-    assert len(results) == 10
-    assert results[0]["body"] == 'Message Number 100'
+    page_2 = ChatMessages.objects(
+        chat_id=str(chat_record.chat_id)
+    ).filter(time__lt=last_time).limit(5)
 
-    last_time = results[9]["time"]
+    assert len(page_2) == 5
+    assert page_2[0]["body"] == conversation[7].body
+    assert page_2[1]["body"] == conversation[6].body
+    assert page_2[2]["body"] == conversation[5].body
+    assert page_2[3]["body"] == conversation[4].body
+    assert page_2[4]["body"] == conversation[3].body
 
-    results = ChatMessages.objects(
-        from_user=from_user_id, to_user=to_user_id
-    ).filter(time__lt=last_time).limit(10)
+    last_time = page_2[4]["time"]
 
-    assert len(results) == 10
-    assert results[0]["body"] == 'Message Number 90'
+    page_3 = ChatMessages.objects(
+        chat_id=str(chat_record.chat_id)
+    ).filter(time__lt=last_time).limit(5)
 
-    last_time = results[9]["time"]
-
-    results = ChatMessages.objects(
-        from_user=from_user_id, to_user=to_user_id
-    ).filter(time__lt=last_time).limit(10)
-
-    assert len(results) == 10
-    assert results[0]["body"] == 'Message Number 80'
-
-    # SHEEESH
-
+    assert len(page_3) == 3
+    assert page_3[0]["body"] == conversation[2].body
+    assert page_3[1]["body"] == conversation[1].body
+    assert page_3[2]["body"] == conversation[0].body

--- a/chat-microservice/app/tests/cassandra/test_chat_model.py
+++ b/chat-microservice/app/tests/cassandra/test_chat_model.py
@@ -1,0 +1,39 @@
+import uuid
+
+from app.models.chat import Chat
+
+def test_create_a_single_record(cassandra_session):
+    model_instance = Chat.create(
+        chat_id = str(uuid.uuid4()),
+        users_id = [str(uuid.uuid4()), str(uuid.uuid4())],
+        users_name = ["Frank", "Pepe"]
+    )
+    assert Chat.objects().count() == 1
+
+def test_chat_id_must_be_unique(cassandra_session):
+    chat_id_unique = str(uuid.uuid4())
+    for _ in range(3):
+        Chat.create(
+            chat_id = chat_id_unique,
+            users_id = [str(uuid.uuid4()), str(uuid.uuid4())],
+            users_name = ["Frank", "Pepe"]
+        )
+    assert Chat.objects().count() == 1
+
+def test_find_all_franks_chat(cassandra_session):
+    frank_id = str(uuid.uuid4())
+    for _ in range(3):
+        Chat.create(
+            chat_id = str(uuid.uuid4()),
+            users_id = [frank_id, str(uuid.uuid4())],
+            users_name = ["Frank", "Pepe"]
+        )
+    for _ in range(3):
+        Chat.create(
+            chat_id = str(uuid.uuid4()),
+            users_id = [str(uuid.uuid4()), str(uuid.uuid4())],
+            users_name = ["Frank", "Pepe"]
+        )
+    assert Chat.objects().count() == 6
+    franks_chat = Chat.objects().filter(users_id__contains=frank_id).allow_filtering()
+    assert franks_chat.count() == 3

--- a/chat-microservice/app/tests/cassandra/test_chat_model.py
+++ b/chat-microservice/app/tests/cassandra/test_chat_model.py
@@ -37,3 +37,26 @@ def test_find_all_franks_chat(cassandra_session):
     assert Chat.objects().count() == 6
     franks_chat = Chat.objects().filter(users_id__contains=frank_id).allow_filtering()
     assert franks_chat.count() == 3
+
+def test_users_belongs_to_chat_method(cassandra_session):
+    from_user_id, to_user_id = [str(uuid.uuid4()), str(uuid.uuid4())]
+    first_chat = Chat.create(
+        chat_id = str(uuid.uuid4()),
+        users_id = [from_user_id, to_user_id],
+        users_name = ["Frank", "Pepe"]
+    )
+    second_chat = Chat.create(
+        chat_id = str(uuid.uuid4()),
+        users_id = [from_user_id, str(uuid.uuid4())],
+        users_name = ["Frank", "Manuel"]
+    )
+    assert first_chat.users_id_belongs_to_chat(
+        first_chat.chat_id, 
+        from_user_id, 
+        to_user_id
+    ) == True
+    assert first_chat.users_id_belongs_to_chat(
+        first_chat.chat_id, 
+        from_user_id, 
+        str(uuid.uuid4())
+    ) == False

--- a/chat-microservice/app/tests/cassandra/test_chat_model.py
+++ b/chat-microservice/app/tests/cassandra/test_chat_model.py
@@ -54,9 +54,9 @@ def test_users_belongs_to_chat_method(cassandra_session):
         first_chat.chat_id, 
         from_user_id, 
         to_user_id
-    ) == True
+    ) is True
     assert first_chat.users_id_belongs_to_chat(
         first_chat.chat_id, 
         from_user_id, 
         str(uuid.uuid4())
-    ) == False
+    ) is False

--- a/chat-microservice/app/tests/conftest.py
+++ b/chat-microservice/app/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import uuid
 
 from jose import jwt
 
@@ -22,6 +23,9 @@ from datetime import datetime, timedelta
 
 
 keyspace = settings.CASSANDRA_KEYSPACE_TESTING
+
+MAIN_FROM_USER_ID = "1"
+MAIN_TO_USER_ID = "2"
 
 @pytest.fixture()
 def cassandra_session():
@@ -70,27 +74,32 @@ async def client():
         yield ac
 
 @pytest.fixture()
-def current_user_id():
-    return "1"
+def main_from_user_uid():
+    return MAIN_FROM_USER_ID
 
 @pytest.fixture()
-def user_token_header(current_user_id: str) -> dict[str, str]:
+def main_to_user_uid():
+    return MAIN_TO_USER_ID
+
+@pytest.fixture()
+def user_token_header(main_from_user_uid: str) -> dict[str, str]:
     access_token = jwt.encode(
         {
             "exp": datetime.utcnow() + timedelta(minutes=30), 
-            "user_id": current_user_id
+            "user_id": main_from_user_uid
         },
         key=settings.SECRET_KEY.get_secret_value(),
         algorithm=settings.ALGORITHM
     )
+
     return {"Authorization": f"Bearer {access_token}"}
 
 @pytest.fixture()
-def unauthorized_user_token_header(current_user_id: str) -> dict[str, str]:
+def unauthorized_user_token_header() -> dict[str, str]:
     access_token = jwt.encode(
         {
             "exp": datetime.utcnow() + timedelta(minutes=30), 
-            "user_id": "2"
+            "user_id": "3"
         },
         key=settings.SECRET_KEY.get_secret_value(),
         algorithm=settings.ALGORITHM

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,25 +19,33 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
     depends_on:
       - zookeeper
-
-  
-#   auth_db:
-#     image: postgres
-#     volumes:
-#       - auth_db_data:/var/lib/postgresql/data
-#     environment:
-#       POSTGRES_DB: auth_microservice
-#       POSTGRES_USER: auth_microservice
-#       POSTGRES_PASSWORD: auth_microservice
-#     ports:
-#       - '5433:5432'
-# volumes:
-#   zookeeper_data:
-#     driver: local
-#   kafka_data:
-#     driver: local
-#   auth_db_data:
-#     driver: local
+  cassandra:
+    image: 'cassandra:4.0'
+    volumes:
+      - messaging_db_volume:/var/lib/cassandra
+    environment:
+      - CASSANDRA_CLUSTER_NAME=book
+    ports:
+      - '9042:9042'
+  auth_db:
+    image: postgres
+    volumes:
+      - auth_db_volume:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: auth_microservice
+      POSTGRES_USER: auth_microservice
+      POSTGRES_PASSWORD: auth_microservice
+    ports:
+      - '5433:5432'
+volumes:
+  zookeeper_data:
+    driver: local
+  kafka_data:
+    driver: local
+  auth_db_volume:
+    driver: local
+  messaging_db_volume:
+    driver: local
 
 # https://hub.docker.com/r/bitnami/kafka/
 # https://github.com/wurstmeister/kafka-docker/issues/389#issuecomment-416884988


### PR DESCRIPTION
- [x] Create Chat Table
- [x] Modify Message Table to add chat id
- [x] Create endpoint `/create-chat`
- [x] Create tests for new endpoint and update test of create_message because I need test the validation for chat_id and users_id
- [x] Add validation to create_message endpoint to verify if the user that send the message is inside of users_id column in the chat record
- [x] Add realtime flow architecture image to README
- [x] Bug: When the chat API tests are running they are using the development cassandra cluster and not the testing env one
- [x] Add cassandra to the docker compose